### PR TITLE
add additional supported platforms to test-kitchen

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,5 @@ rvm:
 services:
   - docker
 
-before_install:
-  - bundle install
-
 script:
-  - bundle exec kitchen test install-source
+  - bundle exec kitchen test install-source -c

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,7 +3,7 @@
 
 - name: restart geth
   service: name=geth state=restarted
-  when: manage_service
+  when: manage_service|bool
 
 #######  UNINSTALL operations #######
 
@@ -43,7 +43,7 @@
     path: "{{ install_dir }}"
     state: absent
   become: true
-  when: perform_uninstall
+  when: perform_uninstall|bool
 
 - name: check config dir uninstall
   file:
@@ -57,7 +57,7 @@
     path: "{{ geth_config.Node.DataDir }}"
     state: absent
   become: true
-  when: perform_uninstall
+  when: perform_uninstall|bool
 
 # -------------------------------- #
 

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -19,8 +19,13 @@ verifier:
   name: inspec
 
 platforms:
-  - name: ubuntu-18.04
   - name: centos-7
+  - name: fedora-28
+  - name: fedora-29
+  - name: ubuntu-16.04
+  - name: ubuntu-18.04
+  - name: debian-8
+  - name: debian-9
 
 suites:
   - name: install_package
@@ -31,6 +36,10 @@ suites:
         - path: test/integration/install/install_package
     excludes:
       - centos-7
+      - fedora-28
+      - fedora-29
+      - debian-8
+      - debian-9
 
   - name: install_source
     provisioner:

--- a/tasks/common/config.yml
+++ b/tasks/common/config.yml
@@ -8,7 +8,7 @@
     owner: "{{ geth_user }}"
     group: "{{ geth_user }}"
   become: true
-  when: geth_config
+  when: geth_config|bool
   notify:
     - check config dir uninstall
 
@@ -20,7 +20,7 @@
     group: "{{ geth_user }}"
     mode: 0644
   become: true
-  when: geth_config
+  when: geth_config|bool
   notify:
     - restart geth
     - check config dir uninstall
@@ -32,6 +32,6 @@
     owner: "{{ geth_user }}"
     group: "{{ geth_user }}"
   become: true
-  when: geth_config
+  when: geth_config|bool
   notify:
     - check data dir uninstall


### PR DESCRIPTION
* additional platforms consist of centos, fedora, ubuntu and debian variants previously not included
* also, fixed a few ansible warnings